### PR TITLE
Fixed typo in for loop within flag_stable_baseflow

### DIFF
--- a/MainAnalysisFunctionsPt1.R
+++ b/MainAnalysisFunctionsPt1.R
@@ -61,7 +61,7 @@ flag_stable_baseflow <- function(df,
   for(i in 1:length(df$RecessionDay)) {
     # Compare flow at i to overall mean flow
     if (flow_col[i] >= 1.15 * mean(flow_col, na.rm = TRUE)) {
-      df$RecessionDay[1] <- FALSE
+      df$RecessionDay[i] <- FALSE
     }
     return(df)
   }

--- a/MainAnalysisFunctionsPt1.R
+++ b/MainAnalysisFunctionsPt1.R
@@ -61,7 +61,7 @@ flag_stable_baseflow <- function(df,
   for(i in 1:length(df$RecessionDay)) {
     # Compare flow at i to overall mean flow
     if (flow_col[i] >= 1.15 * mean(flow_col, na.rm = TRUE)) {
-      df$RecessionDay <- FALSE
+      df$RecessionDay[1] <- FALSE
     }
     return(df)
   }


### PR DESCRIPTION
@benhdye @willprokopik @ilonah22 There was an issue in `flag_stable_baseflow()` that was cropping up when I was trying to run certain gages. The function wasn't storing the updated `RecessionDay` after checking the Q > 1.15 * mean(Q) due to a missing index. Any issues with me to merging this in?